### PR TITLE
fix: restore URL opening in news feed and deep links

### DIFF
--- a/core/ui/src/commonMain/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsFeed.kt
+++ b/core/ui/src/commonMain/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsFeed.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalUriHandler
 import com.google.samples.apps.nowinandroid.core.analytics.LocalAnalyticsHelper
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
 import com.google.samples.apps.nowinandroid.core.model.data.UserNewsResource
@@ -51,6 +52,7 @@ fun LazyStaggeredGridScope.newsFeed(
                 contentType = { "newsFeedItem" },
             ) { userNewsResource ->
                 val analyticsHelper = LocalAnalyticsHelper.current
+                val uriHandler = LocalUriHandler.current
                 NewsResourceCardExpanded(
                     userNewsResource = userNewsResource,
                     isBookmarked = userNewsResource.isSaved,
@@ -59,7 +61,7 @@ fun LazyStaggeredGridScope.newsFeed(
                         analyticsHelper.logNewsResourceOpened(
                             newsResourceId = userNewsResource.id,
                         )
-                        launchCustomChromeTab(userNewsResource.url)
+                        uriHandler.openUri(userNewsResource.url)
 
                         onNewsResourceViewed(userNewsResource.id)
                     },
@@ -78,10 +80,6 @@ fun LazyStaggeredGridScope.newsFeed(
             }
         }
     }
-}
-
-fun launchCustomChromeTab(uri: String) {
-    // Empty implementation
 }
 
 /**

--- a/core/ui/src/commonMain/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsFeed.kt
+++ b/core/ui/src/commonMain/kotlin/com/google/samples/apps/nowinandroid/core/ui/NewsFeed.kt
@@ -24,10 +24,10 @@ import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.platform.LocalUriHandler
 import com.google.samples.apps.nowinandroid.core.analytics.LocalAnalyticsHelper
 import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
 import com.google.samples.apps.nowinandroid.core.model.data.UserNewsResource

--- a/feature/foryou/impl/src/commonMain/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
+++ b/feature/foryou/impl/src/commonMain/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
@@ -87,7 +87,6 @@ import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
 import com.google.samples.apps.nowinandroid.core.model.data.UserNewsResource
 import com.google.samples.apps.nowinandroid.core.ui.DevicePreviews
 import com.google.samples.apps.nowinandroid.core.ui.NewsFeedUiState
-import com.google.samples.apps.nowinandroid.core.ui.TrackScrollJank
 import com.google.samples.apps.nowinandroid.core.ui.TrackScreenViewEvent
 import com.google.samples.apps.nowinandroid.core.ui.UserNewsResourcePreviewParameterProvider
 import com.google.samples.apps.nowinandroid.core.ui.collectAsStateWithLifecycle

--- a/feature/foryou/impl/src/commonMain/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
+++ b/feature/foryou/impl/src/commonMain/kotlin/com/google/samples/apps/nowinandroid/feature/foryou/ForYouScreen.kt
@@ -59,11 +59,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -85,6 +87,7 @@ import com.google.samples.apps.nowinandroid.core.designsystem.theme.NiaTheme
 import com.google.samples.apps.nowinandroid.core.model.data.UserNewsResource
 import com.google.samples.apps.nowinandroid.core.ui.DevicePreviews
 import com.google.samples.apps.nowinandroid.core.ui.NewsFeedUiState
+import com.google.samples.apps.nowinandroid.core.ui.TrackScrollJank
 import com.google.samples.apps.nowinandroid.core.ui.TrackScreenViewEvent
 import com.google.samples.apps.nowinandroid.core.ui.UserNewsResourcePreviewParameterProvider
 import com.google.samples.apps.nowinandroid.core.ui.collectAsStateWithLifecycle
@@ -460,19 +463,14 @@ private fun DeepLinkEffect(
     userNewsResource: UserNewsResource?,
     onDeepLinkOpened: (String) -> Unit,
 ) {
-//    val context = LocalContext.current
-//    val backgroundColor = MaterialTheme.colorScheme.background.toArgb()
-//
-//    LaunchedEffect(userNewsResource) {
-//        if (userNewsResource == null) return@LaunchedEffect
-//        if (!userNewsResource.hasBeenViewed) onDeepLinkOpened(userNewsResource.id)
-//
-//        launchCustomChromeTab(
-//            context = context,
-//            uri = Uri.parse(userNewsResource.url),
-//            toolbarColor = backgroundColor,
-//        )
-//    }
+    val uriHandler = LocalUriHandler.current
+
+    LaunchedEffect(userNewsResource) {
+        if (userNewsResource == null) return@LaunchedEffect
+        if (!userNewsResource.hasBeenViewed) onDeepLinkOpened(userNewsResource.id)
+
+        uriHandler.openUri(userNewsResource.url)
+    }
 }
 
 private fun feedItemsSize(


### PR DESCRIPTION
Replace the empty launchCustomChromeTab() stub with LocalUriHandler.openUri() from Compose Multiplatform, restoring the ability to open news resource URLs when clicking cards. Also restore the DeepLinkEffect body in ForYouScreen which was entirely commented out.

- NewsFeed.kt: capture LocalUriHandler in composable scope, use openUri()
- ForYouScreen.kt: restore DeepLinkEffect with LocalUriHandler + LaunchedEffect
- Remove the dead launchCustomChromeTab() function
